### PR TITLE
add status skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Yet Another GitHub Action to notify slack.
 | text_on_success   | any string                                                 | ''                    | `text` field on success                   |
 | text_on_fail      | any string                                                 | ''                    | `text` field on failure                   |
 | text_on_cancel    | any string                                                 | ''                    | `text` field on cancellation              |
+| text_on_skipped   | any string                                                 | ''                    | `text` field on skipped                   |
 | title             | any string                                                 | workflow name         | `title` field                             |
 | mention           | 'here' or 'channel' or user\_id such as `user_id,user_id2` | ''                    | Mention always if specified. The user ID should be an ID, such as `@U024BE7LH`. See [Mentioning Users](https://api.slack.com/reference/surfaces/formatting#mentioning-users) |
 | only_mention_fail | 'here' or 'channel' or user\_id such as `user_id,user_id2` | ''                    | Mention only on failure if specified      |

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: override the legacy integration's default channel. This should be an ID, such as C8UJ12P4P.
     default: ''
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: bell

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^13.1.1",
         "@types/semver": "^6.2.0",
         "@typescript-eslint/parser": "^2.13.0",
+        "@vercel/ncc": "^0.38.1",
         "@zeit/ncc": "^0.20.5",
         "codecov": "^3.8.3",
         "eslint": "^6.8.0",
@@ -2949,6 +2950,15 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/@zeit/ncc": {
@@ -15852,6 +15862,12 @@
           "dev": true
         }
       }
+    },
+    "@vercel/ncc": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
+      "dev": true
     },
     "@zeit/ncc": {
       "version": "0.20.5",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/node": "^13.1.1",
     "@types/semver": "^6.2.0",
     "@typescript-eslint/parser": "^2.13.0",
+    "@vercel/ncc": "^0.38.1",
     "@zeit/ncc": "^0.20.5",
     "codecov": "^3.8.3",
     "eslint": "^6.8.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,7 @@ export interface With {
   text_on_success: string;
   text_on_fail: string;
   text_on_cancel: string;
+  text_on_skipped: string;
   title: string;
   only_mention_fail: string;
   username: string;
@@ -62,6 +63,14 @@ export class Client {
     const template = await this.payloadTemplate();
     template.attachments[0].color = 'warning';
     template.text += this.textCancel;
+
+    return template;
+  }
+
+  async skipped() {
+    const template = await this.payloadTemplate();
+    template.attachments[0].color = 'good';
+    template.text += this.textSkipped;
 
     return template;
   }
@@ -168,6 +177,16 @@ export class Client {
       return this.with.text;
     }
     return 'A GitHub Action has been cancelled';
+  }
+
+  private get textSkipped() {
+    if (this.with.text_on_skipped !== '') {
+      return this.with.text_on_skipped;
+    }
+    if (this.with.text !== '') {
+      return this.with.text;
+    }
+    return 'A GitHub Action has been skipped';
   }
 
   private get title() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function run(): Promise<void> {
     const text_on_success = core.getInput('text_on_success');
     const text_on_fail = core.getInput('text_on_fail');
     const text_on_cancel = core.getInput('text_on_cancel');
+    const text_on_skipped = core.getInput('text_on_skipped');
     const username = core.getInput('username');
     const icon_emoji = core.getInput('icon_emoji');
     const icon_url = core.getInput('icon_url');
@@ -27,6 +28,7 @@ async function run(): Promise<void> {
     core.debug(`text_on_success: ${text_on_success}`);
     core.debug(`text_on_fail: ${text_on_fail}`);
     core.debug(`text_on_cancel: ${text_on_cancel}`);
+    core.debug(`text_on_skipped: ${text_on_skipped}`);
     core.debug(`username: ${username}`);
     core.debug(`icon_emoji: ${icon_emoji}`);
     core.debug(`icon_url: ${icon_url}`);
@@ -41,6 +43,7 @@ async function run(): Promise<void> {
         text_on_success,
         text_on_fail,
         text_on_cancel,
+        text_on_skipped,
         title,
         only_mention_fail,
         username,
@@ -61,6 +64,9 @@ async function run(): Promise<void> {
         break;
       case 'cancelled':
         await client.send(await client.cancel());
+        break;
+      case 'skipped':
+        await client.send(await client.skipped());
         break;
       case 'custom':
         /* eslint-disable no-var */


### PR DESCRIPTION
## Issue
CI is skipped, and the status of sonots/slack-notice-action@v3.1.6 is marked as skipped, but the value is invalid and causes an error.

## Resolution
- Updated to tolerate "skipped" status.
- Added `@vercel/ncc` package due to compatibility issues between ncc and node versions, which caused the following error
   - Error log: https://github.com/shutosekiguchi/slack-notice-action/actions/runs/8386520680/job/22967047589
   - Additional command: `npm install --save-dev @vercel/ncc`
