### PR TITLE
Removed @zeit/ncc in favor of @vercel/ncc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@types/semver": "^6.2.0",
         "@typescript-eslint/parser": "^2.13.0",
         "@vercel/ncc": "^0.38.1",
-        "@zeit/ncc": "^0.20.5",
         "codecov": "^3.8.3",
         "eslint": "^6.8.0",
         "eslint-plugin-github": "^3.4.0",
@@ -2956,15 +2955,6 @@
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
       "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
-      "dev": true,
-      "bin": {
-        "ncc": "dist/ncc/cli.js"
-      }
-    },
-    "node_modules/@zeit/ncc": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz",
-      "integrity": "sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -15867,12 +15857,6 @@
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
       "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
-      "dev": true
-    },
-    "@zeit/ncc": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz",
-      "integrity": "sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==",
       "dev": true
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/semver": "^6.2.0",
     "@typescript-eslint/parser": "^2.13.0",
     "@vercel/ncc": "^0.38.1",
-    "@zeit/ncc": "^0.20.5",
     "codecov": "^3.8.3",
     "eslint": "^6.8.0",
     "eslint-plugin-github": "^3.4.0",


### PR DESCRIPTION
Fix for PR #1 
`@vercel/ncc` and `@zeit/ncc` refer to different versions of the same tool. Since `@zeit/ncc` is the older version, it will be removed.